### PR TITLE
Adds Okta integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,13 @@
             <version>1.22.0</version>
         </dependency>
 
+        <!-- Okta Libraries and APIs -->
+        <dependency>
+            <groupId>com.okta.jwt</groupId>
+            <artifactId>okta-jwt-verifier</artifactId>
+            <version>0.3.2</version>
+        </dependency>
+
         <!-- Json Web Tokens -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -216,6 +223,26 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>5.1.4</version>
+                <configuration>
+                    <url>jdbc:postgresql://localhost:5432/ego?stringtype=unspecified</url>
+                    <user>postgres</user>
+                    <password>password</password>
+                    <locations>filesystem:src/main/resources/flyway/sql,classpath:db.migration</locations>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>42.1.4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>

--- a/src/main/java/org/overture/ego/controller/AuthController.java
+++ b/src/main/java/org/overture/ego/controller/AuthController.java
@@ -20,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.overture.ego.provider.Okta.OktaTokenService;
 import org.overture.ego.provider.facebook.FacebookTokenService;
 import org.overture.ego.provider.google.GoogleTokenService;
 import org.overture.ego.token.TokenService;
@@ -42,6 +43,7 @@ public class AuthController {
   private TokenService tokenService;
   private GoogleTokenService googleTokenService;
   private FacebookTokenService facebookTokenService;
+  private OktaTokenService oktaTokenService;
   private TokenSigner tokenSigner;
 
   @RequestMapping(method = RequestMethod.GET, value = "/google/token")
@@ -70,6 +72,16 @@ public class AuthController {
     } else {
       throw new InvalidTokenException("Unable to generate auth token for this user");
     }
+  }
+
+  @RequestMapping(method = RequestMethod.GET, value = "/okta/token")
+  @ResponseStatus(value = HttpStatus.OK)
+  @SneakyThrows
+  public @ResponseBody
+  String exchangeOtkaTokenForAuth(
+          @RequestHeader(value = "token", required = true) final String idToken) {
+    val authInfo = oktaTokenService.verify(idToken);
+    return tokenService.generateUserToken(authInfo);
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/token/verify")

--- a/src/main/java/org/overture/ego/provider/Okta/OktaTokenService.java
+++ b/src/main/java/org/overture/ego/provider/Okta/OktaTokenService.java
@@ -1,0 +1,36 @@
+package org.overture.ego.provider.Okta;
+
+import com.okta.jwt.Jwt;
+import com.okta.jwt.JwtHelper;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.overture.ego.token.IDToken;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OktaTokenService {
+
+    @Value("${okta.clientId}")
+    private String clientId;
+    @Value("${okta.issuerUrl}")
+    private String issuerUrl;
+    @Value("${okta.audience}")
+    private String audience;
+
+    @SneakyThrows
+    public IDToken verify(String jwtString) {
+        val jwtVerifier = new JwtHelper()
+                .setIssuerUrl(issuerUrl)
+                .setAudience(audience)
+                .setConnectionTimeout(2000)
+                .setReadTimeout(2000)
+                .setClientId(clientId)
+                .build();
+
+        val jwt = jwtVerifier.decodeIdToken(jwtString, null);
+        val claims = jwt.getClaims();
+        return IDToken.builder().email(claims.get("email").toString()).build();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring.datasource:
   url: jdbc:postgresql://localhost:5432/ego?stringtype=unspecified
 
   username: postgres
-  password:
+  password: password
   max-active: 10
   max-idle: 1
   min-idle: 1
@@ -45,6 +45,12 @@ facebook:
 google:
   client:
     Ids: 144611473365-k1aarg8qs6rlh67r3t7dssi1e34b6061.apps.googleusercontent.com
+
+okta:
+  clientId:
+  issuerUrl:
+  audience:
+
 
 # Logging settings.
 logging:

--- a/src/main/resources/flyway/conf/flyway.conf
+++ b/src/main/resources/flyway/conf/flyway.conf
@@ -45,7 +45,7 @@ flyway.url=jdbc:postgresql://localhost:5432/ego?stringtype=unspecified
 flyway.user=postgres
 
 # Password to use to connect to the database. Flyway will prompt you to enter it if not specified.
-# flyway.password=
+flyway.password=password
 
 # Comma-separated list of schemas managed by Flyway. These schema names are case-sensitive.
 # (default: The default schema for the datasource connection)


### PR DESCRIPTION
# Summary
This PR adds the abililty to treat Okta as an identity provider and exchanges a valid okta ID token for an Ego JWT. It will create a user entry in the process for the initial login. 

# Changes
- Endpoint for accepting Okta Id Tokens
- Verifies Okta idToken with Okta's JWT verifier
- Adds flyway config with maven plugin for better windows builds